### PR TITLE
Update redirect of ros2 to http://index.ros.org/doc/ros2

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   </head>
   <body bgcolor="#ffffff">
     <center>
-      You are being redirect to <a href="https://github.com/ros2/ros2/wiki">https://github.com/ros2/ros2/wiki</a>...
+      You are being redirect to <a href="http://index.ros.org/doc/ros2">http://index.ros.org/doc/ros2</a>...
     </center>
   </body>
 </html>


### PR DESCRIPTION
Follow up to https://github.com/ros-infrastructure/rosindex/issues/90 moving ROS2 wiki onto index.ros.org